### PR TITLE
Add more inputs to the action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,21 @@ inputs:
     description: 'A string input with or without delimiter.'
     required: true
 
+  delimiter:
+    description: 'A delimiter to parse the input string.'
+    required: false
+    default: ','
+  
+  run-all-default-values:
+    description: 'A default value to return if `ALL`or `all` is passed as input.'
+    required: false
+
 outputs:
   parsed:
     description: 'A parsed unput supported by job matrix to run furthers steps/jobs parallely.'
+  
+  is-empty:
+    description: 'A boolean value to check if the output is empty or not.'
 
 runs:
   using: 'node20'

--- a/dist/index.js
+++ b/dist/index.js
@@ -27541,15 +27541,29 @@ module.exports = parseParams
 var __webpack_exports__ = {};
 const core = __nccwpck_require__(7484);
 
+const RUN_ALL_IDENTIFIER = 'all'
+
 try {
   // Get input value
-  const inpputString = core.getInput('value');
-  const splittedString = inpputString.split(',');
+  const inputString = core.getInput('value');
+  const inputDelimter = core.getInput('delimiter');
+  const runAllDefaultValues = core.getInput('run-all-default-values');
+
+  let inputValueToSplit = inputString;
+
+  if (inputString.toLowerCase() === RUN_ALL_IDENTIFIER) {
+    inputValueToSplit = runAllDefaultValues;
+  }
+
+  const splittedString = inputValueToSplit.split(inputDelimter || ',').filter(Boolean);
 
   // Set an output value
-  const exampleOutput = `Output derived from ${splittedString}`;
-  console.log("🚀 ~ exampleOutput:", exampleOutput)
-  core.setOutput('parsed', splittedString);
+  if (splittedString.length) {
+    core.setOutput('parsed', splittedString);
+    core.setOutput('is-empty', false);
+  } else {
+    core.setOutput('is-empty', true);
+  }
 
 } catch (error) {
   core.setFailed(error.message);

--- a/index.js
+++ b/index.js
@@ -1,14 +1,28 @@
 const core = require('@actions/core');
 
+const RUN_ALL_IDENTIFIER = 'all'
+
 try {
   // Get input value
-  const inpputString = core.getInput('value');
-  const splittedString = inpputString.split(',');
+  const inputString = core.getInput('value');
+  const inputDelimter = core.getInput('delimiter');
+  const runAllDefaultValues = core.getInput('run-all-default-values');
+
+  let inputValueToSplit = inputString;
+
+  if (inputString.toLowerCase() === RUN_ALL_IDENTIFIER) {
+    inputValueToSplit = runAllDefaultValues;
+  }
+
+  const splittedString = inputValueToSplit.split(inputDelimter || ',').filter(Boolean);
 
   // Set an output value
-  const exampleOutput = `Output derived from ${splittedString}`;
-  console.log("🚀 ~ exampleOutput:", exampleOutput)
-  core.setOutput('parsed', splittedString);
+  if (splittedString.length) {
+    core.setOutput('parsed', splittedString);
+    core.setOutput('is-empty', false);
+  } else {
+    core.setOutput('is-empty', true);
+  }
 
 } catch (error) {
   core.setFailed(error.message);


### PR DESCRIPTION
## Changes

- Add `delimiter` input to determine a custom delimiter to input other than `,`
- Add `run-all-default-values` input to set a default array to be triggered when `all`  is provided as input
- Add `is-empty` as output which can be used to determine if matrix run needs to be skipped